### PR TITLE
nohup not required

### DIFF
--- a/README.md
+++ b/README.md
@@ -2175,7 +2175,7 @@ This will run the given command and keep it running, even after the terminal or 
 
 ```sh
 bkr() {
-    (nohup "$@" &>/dev/null &)
+    ("$@" &>/dev/null &)
 }
 
 bkr ./some_script.sh # some_script.sh is now running in the background


### PR DESCRIPTION
double fork makes PID=1 the parent and thus automatically removes the script from the current session group - and by this will not receive a SIGHUP on exit (which is what we want. Nohup is redundant in this case).